### PR TITLE
fix: tutorials/rmarkdown-dissertation added

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ How to generate articles and presentations for scientific purposes.
    Jupyter](https://github.com/jupyter4edu/jupyter-edu-book/#readme) - Book
    written in R Markdown, bookdown and also rendered as HTML, PDF and
    EPUB.
+- [Write your dissertation in RMarkdown](https://ourcodingclub.github.io/tutorials/rmarkdown-dissertation) - Step-by-step guide on creating a complex pdf document, including text, figures, references, images, formatting, and more.
 - [Writing scientific papers for ACPD using Emacs
    Org-mode](https://www.draketo.de/english/emacs/writing-papers-in-org-mode-acpd) - Detailed
    tutorial on authoring a paper by seamlessly integrating with LaTeX

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Supplementary files and tools.
  and Markdown.
 - [textidote](https://sylvainhalle.github.io/textidote/) - Spelling, grammar and
  style checking on LaTeX documents.
-- [Vale](https://errata-ai.github.io/vale/) - Free, open-source linter for
+- [Vale](https://github.com/errata-ai/vale) - Free, open-source linter for
  prose built with speed and extensibility in mind.
 - [write-good](https://github.com/btford/write-good) - Naive linter for English
  prose.
@@ -184,7 +184,7 @@ How to generate articles and presentations for scientific purposes.
    Jupyter](https://github.com/jupyter4edu/jupyter-edu-book/#readme) - Book
    written in R Markdown, bookdown and also rendered as HTML, PDF and
    EPUB.
-- [Write your dissertation in RMarkdown](https://ourcodingclub.github.io/tutorials/rmarkdown-dissertation) - Step-by-step guide on creating a complex pdf document, including text, figures, references, images, formatting, and more.
+- [Write your dissertation in RMarkdown](https://ourcodingclub.github.io/tutorials/rmarkdown-dissertation/) - Step-by-step guide on creating a complex pdf document, including text, figures, references, images, formatting, and more.
 - [Writing scientific papers for ACPD using Emacs
    Org-mode](https://www.draketo.de/english/emacs/writing-papers-in-org-mode-acpd) - Detailed
    tutorial on authoring a paper by seamlessly integrating with LaTeX


### PR DESCRIPTION
Add / Remove / Edit {entry name} to/from the "{section name}" section.

- [Write your dissertation in RMarkdown](https://ourcodingclub.github.io/tutorials/rmarkdown-dissertation) - Step-by-step guide on creating a complex pdf document, including text, figures, references, images, formatting, and more.

<details>
  <summary>Short pitch</summary>

A really detailed step-by-step guide to creating a thesis with Rmarkdown.

</details>

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [ ] If the entry is a software:
	- [ ] it should be **maintained** (at least a commit / a release in the past 3 years),
	- [ ] it is **open-source** with appropriate **license**
- [ ] Table of contents has been updated (if a section is added / removed).
- [x] Contents have been sorted alphabetically.

<!-- NOTE: Please do not skip the template -->
