### PR TITLE
Quarto to Word Processor (R Studio & VS Code), and tutorials on R Markdown and Quarto from ds-econ.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Supplementary files and tools.
     cross-references.
   - [Panflute](http://scorreia.com/software/panflute/) - Pythonic alternative
     to John MacFarlane's pandocfilters.
-- [Quarto](https://quarto.org) - Compile R Markdown, and Jupyter Notebooks to PDFs, Slides and Websites. Supports R, Python, and Julia. :bookmark: :link:
+- [Quarto](https://quarto.org) - Compile R Markdown, and Jupyter Notebooks to PDFs, Slides and Websites. Supports R, Python, and Julia :bookmark: :link:.
 
 ## Spell Checking and Linting
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ document**.
   - [R Markdown](https://rmarkdown.rstudio.com/) - R package to write R next to Markdown
    :bookmark:
    :link:.
+  - [Quarto](https://quarto.org)
+   :bookmark:
+   :link:
 - [Vim](https://www.vim.org/) - Command line text editor.
   - [fzf-bibtex](https://github.com/msprev/fzf-bibtex/#readme) - BibTeX source
     with Vim integration which uses fzf (a fuzzy finder implemented in Go).
@@ -45,6 +48,9 @@ document**.
 - [Visual Studio Code](https://code.visualstudio.com/) - Popular IDE with Markdown support.
   - [Markdown All in One](https://github.com/yzhang-gh/vscode-markdown/#readme) - Extension for enhanced
     Markdown support in VSCode, such as preview and auto completion to name a few.
+  - [Quarto](https://quarto.org)
+   :bookmark:
+   :link:
 - [Zettlr](https://www.zettlr.com/) - Markdown editor which
    integrates CSL, BibLaTeX, Pandoc and many other tools
    :bookmark: :link:.
@@ -93,6 +99,9 @@ Supplementary files and tools.
 - [nbconvert](https://nbconvert.readthedocs.io/en/latest/) - Convert Jupyter
   notebooks into `reveal.js` presentations, PDF, HTML, Markdown,
   reStructuredText and more.
+- [Quarto](https://quarto.org)
+  :bookmark:
+  :link:
 - [pandoc](https://pandoc.org/MANUAL) - Haskell library for converting from
   one markup format to another, and a command-line tool that uses this
   library :bookmark: :link:.
@@ -182,6 +191,8 @@ How to generate articles and presentations for scientific purposes.
    Org-mode](https://www.draketo.de/english/emacs/writing-papers-in-org-mode-acpd) - Detailed
    tutorial on authoring a paper by seamlessly integrating with LaTeX
    commands within Org-mode.
+- [3 frameworks into one — Write your next paper with R Studio!](https://www.ds-econ.com/write-your-whole-paper-in-r-it-is-better/)
+- [Heads up! Quarto is here to stay. Immediately combine R & Python in your next document](https://www.ds-econ.com/quarto/)
 
 ## Other Lists
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ document**.
 - [Visual Studio Code](https://code.visualstudio.com/) - Popular IDE with Markdown support.
   - [Markdown All in One](https://github.com/yzhang-gh/vscode-markdown/#readme) - Extension for enhanced
     Markdown support in VSCode, such as preview and auto completion to name a few.
-  - [Quarto](https://quarto.org) - Compile R Markdown, and Jupyter Notebooks to PDFs, Slides and Websites. Supports R, Python, and Julia code and its output.
-   :bookmark:
-   :link:
 - [Zettlr](https://www.zettlr.com/) - Markdown editor which
    integrates CSL, BibLaTeX, Pandoc and many other tools
    :bookmark: :link:.
@@ -96,9 +93,6 @@ Supplementary files and tools.
 - [nbconvert](https://nbconvert.readthedocs.io/en/latest/) - Convert Jupyter
   notebooks into `reveal.js` presentations, PDF, HTML, Markdown,
   reStructuredText and more.
-- [Quarto](https://quarto.org)
-  :bookmark:
-  :link:
 - [pandoc](https://pandoc.org/MANUAL) - Haskell library for converting from
   one markup format to another, and a command-line tool that uses this
   library :bookmark: :link:.
@@ -110,6 +104,7 @@ Supplementary files and tools.
     cross-references.
   - [Panflute](http://scorreia.com/software/panflute/) - Pythonic alternative
     to John MacFarlane's pandocfilters.
+- [Quarto](https://quarto.org) - Compile R Markdown, and Jupyter Notebooks to PDFs, Slides and Websites. Supports R, Python, and Julia. :bookmark: :link:
 
 ## Spell Checking and Linting
 
@@ -167,6 +162,7 @@ Reusable minimalist examples.
 ## Tutorials
 
 How to generate articles and presentations for scientific purposes.
+
 - [3 frameworks into one — Write your next paper with R Studio!](https://www.ds-econ.com/write-your-whole-paper-in-r-it-is-better/) - Article provides an overview to a workflow that combines R Markdown (bookdown), Zotero (literature management), and Notion (note taking on research papers) to write academic papers. 
 - [Book on Riemann solvers](https://github.com/clawpack/riemann_book/#readme) - This
    example uses a custom `nbconvert` template and shows how to store your

--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ document**.
   - [R Markdown](https://rmarkdown.rstudio.com/) - R package to write R next to Markdown
    :bookmark:
    :link:.
-  - [Quarto](https://quarto.org)
-   :bookmark:
-   :link:
 - [Vim](https://www.vim.org/) - Command line text editor.
   - [fzf-bibtex](https://github.com/msprev/fzf-bibtex/#readme) - BibTeX source
     with Vim integration which uses fzf (a fuzzy finder implemented in Go).
@@ -48,7 +45,7 @@ document**.
 - [Visual Studio Code](https://code.visualstudio.com/) - Popular IDE with Markdown support.
   - [Markdown All in One](https://github.com/yzhang-gh/vscode-markdown/#readme) - Extension for enhanced
     Markdown support in VSCode, such as preview and auto completion to name a few.
-  - [Quarto](https://quarto.org)
+  - [Quarto](https://quarto.org) - Compile R Markdown, and Jupyter Notebooks to PDFs, Slides and Websites. Supports R, Python, and Julia code and its output.
    :bookmark:
    :link:
 - [Zettlr](https://www.zettlr.com/) - Markdown editor which
@@ -170,14 +167,14 @@ Reusable minimalist examples.
 ## Tutorials
 
 How to generate articles and presentations for scientific purposes.
-- [3 frameworks into one — Write your next paper with R Studio!](https://www.ds-econ.com/write-your-whole-paper-in-r-it-is-better/)
+- [3 frameworks into one — Write your next paper with R Studio!](https://www.ds-econ.com/write-your-whole-paper-in-r-it-is-better/) - Article provides an overview to a workflow that combines R Markdown (bookdown), Zotero (literature management), and Notion (note taking on research papers) to write academic papers. 
 - [Book on Riemann solvers](https://github.com/clawpack/riemann_book/#readme) - This
    example uses a custom `nbconvert` template and shows how to store your
    notebooks with no output (for version control) while automatically executing
    them before running `bookbook`, so that PDF and HTML versions include the
    output.
 - [Dennis Tenen and Grant Wythoff](https://programminghistorian.org/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown) - Sustainable Authorship in Plain Text using Pandoc and Markdown.
-- [Heads up! Quarto is here to stay. Immediately combine R & Python in your next document](https://www.ds-econ.com/quarto/)
+- [Heads up! Quarto is here to stay. Immediately combine R & Python in your next document](https://www.ds-econ.com/quarto/) - Summary of the capabilities of Quarto, why to use it, and how it compares to R Markdown. Also contains tips for M1 Mac users on how to fix a common problem with reticulate.
 - [Katrin Leinweber's Ph.D.
    thesis](https://github.com/katrinleinweber/PhD-thesis/#readme) - Automated
    work flow involving several tools, but primarily Pandoc, `latexmk` and

--- a/README.md
+++ b/README.md
@@ -170,13 +170,14 @@ Reusable minimalist examples.
 ## Tutorials
 
 How to generate articles and presentations for scientific purposes.
-
+- [3 frameworks into one — Write your next paper with R Studio!](https://www.ds-econ.com/write-your-whole-paper-in-r-it-is-better/)
 - [Book on Riemann solvers](https://github.com/clawpack/riemann_book/#readme) - This
    example uses a custom `nbconvert` template and shows how to store your
    notebooks with no output (for version control) while automatically executing
    them before running `bookbook`, so that PDF and HTML versions include the
    output.
 - [Dennis Tenen and Grant Wythoff](https://programminghistorian.org/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown) - Sustainable Authorship in Plain Text using Pandoc and Markdown.
+- [Heads up! Quarto is here to stay. Immediately combine R & Python in your next document](https://www.ds-econ.com/quarto/)
 - [Katrin Leinweber's Ph.D.
    thesis](https://github.com/katrinleinweber/PhD-thesis/#readme) - Automated
    work flow involving several tools, but primarily Pandoc, `latexmk` and
@@ -191,8 +192,6 @@ How to generate articles and presentations for scientific purposes.
    Org-mode](https://www.draketo.de/english/emacs/writing-papers-in-org-mode-acpd) - Detailed
    tutorial on authoring a paper by seamlessly integrating with LaTeX
    commands within Org-mode.
-- [3 frameworks into one — Write your next paper with R Studio!](https://www.ds-econ.com/write-your-whole-paper-in-r-it-is-better/)
-- [Heads up! Quarto is here to stay. Immediately combine R & Python in your next document](https://www.ds-econ.com/quarto/)
 
 ## Other Lists
 


### PR DESCRIPTION
Add {quarto} to "{Word processor}" section.
Add {ds-econ tutorials} to {Tutorials} section.

<details>
  <summary>Short pitch</summary>

I added references to quarto: It is a open source framework following a similar style as R Markdown, however it can easily implement the execution of R, Python, Julia and OBJ. Furthermore, its writing is not limited to markdown files, as it can also render Jupyter Notebooks to scientific articles, presentations, and interactive websites. 

Besides adding quarto to this collection I added two tutorials (one for academic writing in R Markdown interconnected with Notion & Zotero, and one for setting up & writing in Quarto) from my own blog.

</details>

## Checklist

- [X] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [X] If the entry is a software:
	- [X] it should be **maintained** (at least a commit / a release in the past 3 years),
	- [X] it is **open-source** with appropriate **license**
- [X] Table of contents has been updated (if a section is added / removed).
- [X] Contents have been sorted alphabetically.

<!-- NOTE: Please do not skip the template -->
