### PR TITLE
Fix link to marktext

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ document**.
 
 ## Word Processors
 
-- [Marktext](https://marktext.app/) - Markdown text editor.
+- [Marktext](https://github.com/marktext/marktext) - Markdown text editor.
 - [R Studio](https://github.com/rstudio/rstudio) - IDE for R.
   - [bookdown](https://github.com/rstudio/bookdown) - R package to facilitate writing books and long-form articles, reports with R Markdown :bookmark: :link:.
   - [R Markdown](https://rmarkdown.rstudio.com/) - R package to write R next to Markdown


### PR DESCRIPTION
Edit Marktext from the "word processors" section.

<details>
  <summary>Short pitch</summary>

Website's domain expired.

</details>

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [x] If the entry is a software:
	- [x] it should be **maintained** (at least a commit / a release in the past 3 years),
	- [ ] it is **open-source** with appropriate **license**
- [ ] Table of contents has been updated (if a section is added / removed).
- [ ] Contents have been sorted alphabetically.

<!-- NOTE: Please do not skip the template -->
