### PR TITLE
Add `Deepnote` as an option under `Word Processors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ document**.
 
 ## Word Processors
 
+- [Deepnote](https://github.com/deepnote/deepnote) - AI-native data notebook and drop-in replacement for Jupyter.
 - [Marktext](https://github.com/marktext/marktext) - Markdown text editor.
 - [R Studio](https://github.com/rstudio/rstudio) - IDE for R.
   - [bookdown](https://github.com/rstudio/bookdown) - R package to facilitate writing books and long-form articles, reports with R Markdown :bookmark: :link:.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ document**.
 
 ## Word Processors
 
-- [Deepnote](https://github.com/deepnote/deepnote) - AI-native data notebook and drop-in replacement for Jupyter.
 - [Marktext](https://github.com/marktext/marktext) - Markdown text editor.
 - [R Studio](https://github.com/rstudio/rstudio) - IDE for R.
   - [bookdown](https://github.com/rstudio/bookdown) - R package to facilitate writing books and long-form articles, reports with R Markdown :bookmark: :link:.
@@ -37,6 +36,7 @@ document**.
   - [vim-pandoc](https://github.com/vim-pandoc/vim-pandoc) - Pandoc integration and utilities for Vim.
   - [vim-pandoc-syntax](https://github.com/vim-pandoc/vim-pandoc-syntax) - Pandoc syntax highlighting for Vim.
 - [Visual Studio Code](https://code.visualstudio.com/) - Popular IDE with Markdown support.
+  - [Deepnote](https://github.com/deepnote/vscode-deepnote) - Extension for editing and running Deepnote notebooks locally.
   - [Markdown All in One](https://github.com/yzhang-gh/vscode-markdown/#readme) - Extension for enhanced
     Markdown support in VSCode, such as preview and auto completion to name a few.
   - [Markdown Preview Enhanced](https://github.com/shd101wyy/markdown-preview-enhanced) - Pandoc


### PR DESCRIPTION
Add Deepnote to the "Word Processors" section.

<details>
  <summary>Short pitch</summary>

[Deepnote](https://github.com/deepnote/deepnote/) is an AI-native data notebook that serves as a modern, _drop-in_ replacement for Jupyter. It's particularly useful for scientific writing workflows because:

* **Why it's awesome**: Deepnote combines the familiarity of Jupyter notebooks with modern features like real-time collaboration, native data integrations, and AI assistance — making it ideal for data-driven scientific work.
* **Workflow integration**: Scientists and researchers can write Python, R, or SQL in notebooks while seamlessly collaborating with team members, similar to how Google Docs works for text documents.
* **Advantages over Jupyter**: Offers a sleek, modern UI, built-in version control, real-time collaboration, and cloud scalability without the setup overhead of traditional Jupyter environments.

</details>

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [x] If the entry is a software:
	- [x] it should be **maintained** (at least a commit / a release in the past 3 years),
	- [x] it is **open-source** with appropriate **license**
- [x] Table of contents has been updated (if a section is added / removed).
- [x] Contents have been sorted alphabetically.