### PR TITLE
Add Paper Format Agent to Converters and Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Supplementary files and tools.
     cross-references.
   - [Panflute](http://scorreia.com/software/panflute/) - Pythonic alternative
     to John MacFarlane's pandocfilters.
+- [Paper Format Agent](https://github.com/zxyasfas/paper_format_agent) - Python
+  tool that reformats academic paper DOCX files to match a format guide, with a
+  content fingerprint that verifies only the formatting changed and the text is
+  left untouched.
 - [Quarto](https://quarto.org) - Compile R Markdown, and Jupyter Notebooks to PDFs, Slides and Websites. Supports R, Python, and Julia :bookmark: :link:.
 
 ## Spell Checking and Linting


### PR DESCRIPTION
### Short pitch
[Paper Format Agent](https://github.com/zxyasfas/paper_format_agent) is an open-source (MIT) Python tool that reformats academic paper DOCX manuscripts — thesis, journal, IEEE/APA — to match a target format guide. What makes it different from a generic Word macro is a **content fingerprint**: it hashes the manuscript's body and table text before and after the formatting pass and refuses to write the output if that text changed, so authors and reviewers get a verifiable guarantee that only the layout moved and not a word of the writing. It runs locally, so private manuscripts never leave the machine.

I placed it in **Converters and Filters** as a DOCX conformance/formatting tool; happy to move it if you feel another section fits better.

### Criteria
- [x] Open-source with a license (MIT)
- [x] Maintained (commits this week; CI-green, 56 tests)
- [x] One entry added
- [x] Sorted alphabetically (between `pandoc` and `Quarto`)
- [x] Table of contents unchanged (no section added or removed)