### PR TITLE
Add latex2arxiv to the "Converters and Filters" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Supplementary files and tools.
   tools to do it :link:.
 - [Jupyter Book](https://jupyterbook.org/en/stable/) - A static site generator which converts
   a collection of CommonMark, MyST markdown and Jupyter notebooks into a HTML website.
+- [latex2arxiv](https://github.com/YuZh98/latex2arxiv) - Command-line tool which converts
+  a LaTeX project into an arXiv-ready ZIP: prunes unused files, strips comments and
+  draft markup, and flags arXiv submission blockers before upload.
 - [MyST](https://myst-parser.readthedocs.io/en/latest/) - Markedly Structured Text,
   a superset of CommonMark markdown with reStructuredText like features.
 - [nbconvert](https://nbconvert.readthedocs.io/en/latest/) - Convert Jupyter


### PR DESCRIPTION
Add latex2arxiv to the "Converters and Filters" section.

<details>
  <summary>Short pitch</summary>

I am the author. latex2arxiv takes a LaTeX project (an Overleaf "Download → Source" zip, a directory, or a git URL) and converts it into an upload-ready arXiv ZIP in one command: it prunes files not reachable from the main `.tex`, strips comments and draft markup, and runs pre-flight checks for things arXiv will reject that compile fine locally — shell-escape packages such as `minted`, biblatex `.bbl` format/backend mismatches, missing index files, oversized figures.

* How I use it: run it on the exported zip right before submission; on a real statistics paper it reduced 934 files / 80.6 MB to 40 files / 3.1 MB ([arXiv:2504.11630](https://arxiv.org/abs/2504.11630)).
* Compared to [arxiv-latex-cleaner](https://github.com/google-research/arxiv-latex-cleaner): that tool cleans the source tree (comments, unused images) but does not validate against arXiv requirements or compile-check; latex2arxiv adds the pre-flight validation and exits non-zero on errors so it also works as a CI gate.
* MIT licensed, Python, actively maintained (v1.3.0 released 2026-07-08); installable from PyPI and Homebrew.

</details>

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [x] If the entry is a software:
	- [x] it should be **maintained** (at least a commit / a release in the past 3 years),
	- [x] it is **open-source** with appropriate **license**
- [x] Table of contents has been updated (if a section is added / removed). — not applicable, no section change
- [x] Contents have been sorted alphabetically.