### PR TITLE
Add CiteVahti (claim-citation linting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Supplementary files and tools.
 
 ## Spell Checking and Linting
 
+- [CiteVahti](https://github.com/heidihelena/citevahti) - Checks whether each cited source supports the claim it backs, like a linter for citations; local-first desktop app with Zotero integration and human-first review.
 - [GNU Aspell](http://aspell.net/) - Command line spell checker.
 - [Hunspell](http://hunspell.github.io/) - Command line spell checker.
 - [LanguageTool](https://languagetool.org/) - Open source grammar, style and


### PR DESCRIPTION
**Pitch:** CiteVahti checks whether each cited source in a manuscript supports the claim it backs — essentially a linter for citations rather than prose. It runs local-first (no manuscript upload), integrates with Zotero, and keeps a human-first review flow: the tool surfaces claim–source pairs, the author rates support.

**Criteria check:**
- Open source: Apache-2.0, https://github.com/heidihelena/citevahti
- Maintained: active development, latest release 0.45 (July 2026)
- One entry, alphabetical position in *Spell Checking and Linting*, TOC unchanged

**Disclosure:** I am the author (clinician-researcher; built it for my own manuscript work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)