### PR TITLE
Add citecheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Reference managers to generate citations, BibTeX, and BibLaTeX files.
 - [Citation Style Language (CSL) styles](https://editor.citationstyles.org/) - Crowdsourced
   repository with over 9000 free CSL citation styles and an online
   editor to create new ones.
+- [citecheck](https://github.com/tobiasosDev/citecheck) - Command-line tool that checks whether the references in a bibliography (BibTeX, RIS, CSL-JSON) exist and haven't been retracted, using the Crossref, OpenAlex, and DOAJ APIs.
 - [JabRef](https://www.jabref.org/) - Open source bibliography reference manager.
 - [Zotero](https://www.zotero.org/) - FOSS tool to collect, organize, cite, and
   share research.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Reference managers to generate citations, BibTeX, and BibLaTeX files.
 - [Citation Style Language (CSL) styles](https://editor.citationstyles.org/) - Crowdsourced
   repository with over 9000 free CSL citation styles and an online
   editor to create new ones.
-- [citecheck](https://github.com/tobiasosDev/citecheck) - Command-line tool that checks whether the references in a bibliography (BibTeX, RIS, CSL-JSON) exist and haven't been retracted, using the Crossref, OpenAlex, and DOAJ APIs.
+- [citecheck](https://github.com/tobiasosDev/citecheck) - Command-line tool that matches BibTeX, RIS, and CSL-JSON references against Crossref and OpenAlex and flags retractions reported by Crossref.
 - [JabRef](https://www.jabref.org/) - Open source bibliography reference manager.
 - [Zotero](https://www.zotero.org/) - FOSS tool to collect, organize, cite, and
   share research.


### PR DESCRIPTION
citecheck is a command-line tool that matches BibTeX, RIS, and CSL-JSON references against Crossref and OpenAlex and flags retractions reported by Crossref. No API key or signup required, and it works directly on exports from Zotero, Mendeley, or EndNote.

It's open-source (MIT licensed) and actively maintained (npm package `citecheck`).