### PR TITLE
Add Typst

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Supplementary files and tools.
   - [Panflute](http://scorreia.com/software/panflute/) - Pythonic alternative
     to John MacFarlane's pandocfilters.
 - [Quarto](https://quarto.org) - Compile R Markdown, and Jupyter Notebooks to PDFs, Slides and Websites. Supports R, Python, and Julia :bookmark: :link:.
+- [Typst](https://github.com/typst/typst) - Markup-based typesetting system with math, bibliography management, and fast incremental compilation to PDF.
 
 ## Spell Checking and Linting
 


### PR DESCRIPTION
Adds the open-source Typst compiler to Converters and Filters, covering a markup-based authoring workflow with math, bibliography management, and incremental PDF compilation.

License: Apache-2.0. [Upstream](https://github.com/typst/typst) shows maintenance within the required three-year window (latest push checked: 2026-09-03).

Validation: `npx --yes awesome-lint` passed in a normal checkout configured with the upstream remote; `git diff --check` passed. One alphabetized entry; no table-of-contents change.

Closes #61.