### PR TITLE
Add MyST Markdown CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Supplementary files and tools.
   a collection of CommonMark, MyST markdown and Jupyter notebooks into a HTML website.
 - [MyST](https://myst-parser.readthedocs.io/en/latest/) - Markedly Structured Text,
   a superset of CommonMark markdown with reStructuredText like features.
+- [MyST Markdown CLI](https://mystmd.org/) - Command-line tools for building scientific documents from MyST Markdown with citations, cross-references, and HTML, PDF, and Word output.
 - [nbconvert](https://nbconvert.readthedocs.io/en/latest/) - Convert Jupyter
   notebooks into `reveal.js` presentations, PDF, HTML, Markdown,
   reStructuredText and more.


### PR DESCRIPTION
Adds the MyST Markdown CLI as a separate entry from the existing Python MyST parser. It builds scientific documents with citations and cross-references to HTML, PDF, and Word.

License: MIT. [Upstream](https://github.com/jupyter-book/mystmd) shows maintenance within the required three-year window (latest push checked: 2026-09-03).

Validation: `npx --yes awesome-lint` passed in a normal checkout configured with the upstream remote; `git diff --check` passed. One alphabetized entry; no table-of-contents change.

Closes #62.