### PR TITLE
Add Manubot

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Supplementary files and tools.
   tools to do it :link:.
 - [Jupyter Book](https://jupyterbook.org/en/stable/) - A static site generator which converts
   a collection of CommonMark, MyST markdown and Jupyter notebooks into a HTML website.
+- [Manubot](https://manubot.org/) - Workflow for writing and publishing scholarly manuscripts with Markdown, persistent-identifier citations, and reproducible builds.
 - [MyST](https://myst-parser.readthedocs.io/en/latest/) - Markedly Structured Text,
   a superset of CommonMark markdown with reStructuredText like features.
 - [nbconvert](https://nbconvert.readthedocs.io/en/latest/) - Convert Jupyter


### PR DESCRIPTION
Adds a Markdown manuscript workflow with persistent-identifier citations and reproducible publishing. Quarto is already listed; this resolves the remaining Manubot suggestion.

License: BSD-2-Clause Plus Patent. [Upstream](https://github.com/manubot/manubot) shows maintenance within the required three-year window (latest push checked: 2026-08-02).

Validation: `npx --yes awesome-lint` passed in a normal checkout configured with the upstream remote; `git diff --check` passed. One alphabetized entry; no table-of-contents change.

Closes #49.