### PR TITLE
Add Zotero OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Reference managers to generate citations, BibTeX, and BibLaTeX files.
   share research.
   - [Better BibTeX for Zotero](https://retorque.re/zotero-better-bibtex/) - Enhanced
     BibTeX / BibLaTeX integration for Zotero.
+  - [Zotero OCR](https://github.com/UB-Mannheim/zotero-ocr) - Plugin that makes scanned PDFs searchable using Tesseract OCR and Poppler.
 - [ZoteroBib](https://zbib.org/) - Online bibliography reference manager.
 
 ## Illustrations


### PR DESCRIPTION
Adds Zotero OCR beneath Zotero so readers can find a tool for making scanned PDFs searchable. The description names its external Tesseract and Poppler dependencies. Upstream documents Zotero 7 installation and its latest release notes compatibility with Zotero 10 beta.

License: AGPL-3.0. [Upstream](https://github.com/UB-Mannheim/zotero-ocr) shows maintenance within the required three-year window (latest push checked: 2026-08-27).

Validation: `npx --yes awesome-lint` passed in a normal checkout configured with the upstream remote; `git diff --check` passed. One alphabetized entry; no table-of-contents change.

Closes #27.