### PR TITLE
Add OpenDraft to Word Processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ document**.
 ## Word Processors
 
 - [Marktext](https://github.com/marktext/marktext) - Markdown text editor.
+- [OpenDraft](https://github.com/federicodeponte/opendraft) - Multi-agent engine that drafts full academic papers with citations verified against OpenAlex, Crossref, and Semantic Scholar; exports PDF, Word, and LaTeX.
 - [R Studio](https://github.com/rstudio/rstudio) - IDE for R.
   - [bookdown](https://github.com/rstudio/bookdown) - R package to facilitate writing books and long-form articles, reports with R Markdown :bookmark: :link:.
   - [R Markdown](https://rmarkdown.rstudio.com/) - R package to write R next to Markdown :bookmark: :link:.


### PR DESCRIPTION
**Short pitch:** [OpenDraft](https://github.com/federicodeponte/opendraft) is an open-source (MIT), actively maintained (latest release v1.8.0, Sep 2026) multi-agent engine for scientific writing. It drafts full academic papers and literature reviews, and — unlike general LLMs — verifies every citation against real academic databases (OpenAlex, Crossref, Semantic Scholar) before rendering, so it does not emit hallucinated references. Output exports to PDF, Word, and LaTeX.

- One entry added, in **Word Processors**, sorted alphabetically (between Marktext and R Studio).
- Open-source with a LICENSE file (MIT).
- Maintained: release v1.8.0, most recent commit Sep 2026.
- No table-of-contents change (no section added/removed).
